### PR TITLE
[Improve]:The hive-exec module should be used instead of the spark-hive module.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@ under the License.
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
-            <version>4.0.0</version>
+            <version>3.1.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@ under the License.
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-hive_2.12</artifactId>
-            <version>3.1.2</version>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <version>4.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,13 @@ under the License.
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_2.12</artifactId>
+            <version>3.1.2</version>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
             <version>4.0.0</version>


### PR DESCRIPTION
Since bitmap-udf only uses hive-udf related interfaces, we shouldn't introduce extra spark related dependencies.
In addition, the spark-hive module should only be used in the test module.